### PR TITLE
Fix Downstream Bug

### DIFF
--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -1,6 +1,6 @@
 ---
 - name: install govendor
-  command: "go get -u github.com/kardianos/govendor"
+  command: "{{ go_goroot_dir }}/bin/go get -u github.com/kardianos/govendor"
   args:
     creates: "{{ go_user_home }}/.go/bin/govendor"
   become: true

--- a/tests/goss.d/commands.yml
+++ b/tests/goss.d/commands.yml
@@ -3,7 +3,10 @@ command:
   'sudo -Hiu {{.Env.go_user}} which govendor':
     exit-status: 0
 
-  '/usr/local/go/bin/go version':
+  'sudo -Hiu {{.Env.go_user}} {{.Env.go_goroot_dir}}/bin/go get -u github.com/spf13/cobra':
+    exit-status: 0
+
+  '{{.Env.go_goroot_dir}}/bin/go version':
     exit-status: 0
     stdout:
       - "{{.Env.go_version}}"

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -25,3 +25,4 @@
       goss_env_vars:
         go_version: 1.8.3
         go_user: vagrant
+        go_goroot_dir: /usr/local/go


### PR DESCRIPTION
Unfortunately unable to reprduce here, but without the full path to the Go binary, go get would fail to install govendor.